### PR TITLE
feat: Add endpoint to close an event early

### DIFF
--- a/controllers/eventsController.js
+++ b/controllers/eventsController.js
@@ -22,6 +22,29 @@ exports.createEvent = async (req, res, next) => {
   }
 };
 
+// @desc    Close an event
+// @route   POST /api/events/:id/close
+// @access  Private/Admin
+exports.closeEvent = async (req, res, next) => {
+  try {
+    let event = await Event.findById(req.params.id);
+
+    if (!event) {
+      return res.status(404).json({ success: false, error: 'Event not found' });
+    }
+
+    event.status = 'closed';
+    await event.save();
+
+    res.status(200).json({
+      success: true,
+      event,
+    });
+  } catch (err) {
+    res.status(400).json({ success: false, error: err.message });
+  }
+};
+
 // @desc    Update an event
 // @route   PUT /api/events/:id
 // @access  Private/Admin

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "testEnvironment": "node",
     "testMatch": [
       "**/test/**/*.js"
+    ],
+    "setupFiles": [
+      "dotenv/config"
     ]
   }
 }

--- a/routes/events.js
+++ b/routes/events.js
@@ -3,6 +3,7 @@ const {
   createEvent,
   cloneEvent,
   updateEvent,
+  closeEvent,
 } = require('../controllers/eventsController');
 const { protect, authorize } = require('../middleware/auth');
 
@@ -11,5 +12,6 @@ const router = express.Router();
 router.post('/', protect, authorize('admin'), createEvent);
 router.post('/clone', protect, authorize('admin'), cloneEvent);
 router.put('/:id', protect, authorize('admin'), updateEvent);
+router.post('/:id/close', protect, authorize('admin'), closeEvent);
 
 module.exports = router;


### PR DESCRIPTION
This commit introduces a new endpoint `POST /api/events/:id/close` that allows an admin to close an ongoing event.

The following changes are included:
- A new `closeEvent` function has been added to `controllers/eventsController.js` to handle the logic for closing an event.
- A new route has been added to `routes/events.js` for the `closeEvent` function.
- The new route is protected by authentication and authorization middleware to ensure that only admins can access it.
- A new test suite has been added to `test/events.js` to verify the functionality of the new endpoint.
- A `.env` file has been added to the project root with a dummy `JWT_SECRET` to allow the tests to run successfully.
- The `package.json` file has been updated to configure Jest to load the `.env` file before running tests.